### PR TITLE
Hide the toolbar when locking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.serwylo.babyphone"
         minSdkVersion 22
         targetSdkVersion 30
-        versionCode 4
-        versionName "0.4.0"
+        versionCode 5
+        versionName "0.4.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/serwylo/babyphone/MainActivity.kt
+++ b/app/src/main/java/com/serwylo/babyphone/MainActivity.kt
@@ -120,7 +120,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.menu_lock -> immersiveLock.startImmersiveMode(this)
+            R.id.menu_lock -> {
+                immersiveLock.startImmersiveMode(this)
+                binding.toolbar.visibility = View.GONE
+            }
             R.id.menu_settings -> startActivity(Intent(this, SettingsActivity::class.java))
         }
         return super.onOptionsItemSelected(item)

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,0 +1,1 @@
+Fix to the baby lock: Hide the toolbar when locked.


### PR DESCRIPTION
Fixes #9.

Arg, the code was specifically **showing** the toolbar when **unlocking**, but neglected to actually **hide** the toolbar when **locking**!. Hopefully fixed now.