### PR TITLE
Added option to share and import Contacts

### DIFF
--- a/app/src/main/java/com/serwylo/babyphone/settingscontactlist/SettingsContactListActivity.kt
+++ b/app/src/main/java/com/serwylo/babyphone/settingscontactlist/SettingsContactListActivity.kt
@@ -19,6 +19,8 @@ import com.serwylo.babyphone.db.AppDatabase
 import com.serwylo.babyphone.db.entities.Contact
 import com.serwylo.babyphone.editcontact.EditContactActivity
 
+private const val PICK_MYFILE_REQUEST = 1
+
 class SettingsContactListActivity : AppCompatActivity() {
 
     private lateinit var viewModel: SettingsContactListViewModel
@@ -78,8 +80,30 @@ class SettingsContactListActivity : AppCompatActivity() {
             R.id.add -> {
                 startActivity(Intent(this, EditContactActivity::class.java))
             }
+
+            R.id.import_contact -> {
+                onImportContact()
+            }
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode == PICK_MYFILE_REQUEST && resultCode == RESULT_OK) {
+
+            startActivity(Intent(this, EditContactActivity::class.java).apply {
+                putExtra(EditContactActivity.IMPORT_CONTACT_URI, data?.data.toString())
+            })
+        }
+    }
+
+    private fun onImportContact() {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.type = "application/zip"
+        intent.addCategory(Intent.CATEGORY_OPENABLE)
+        startActivityForResult(Intent.createChooser(intent, "Select File"), PICK_MYFILE_REQUEST);
     }
 
     private fun onToggleContact(contact: Contact, enabled: Boolean) {

--- a/app/src/main/res/drawable/ic_import.xml
+++ b/app/src/main/res/drawable/ic_import.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M10.09,15.59L11.5,17l5,-5 -5,-5 -1.41,1.41L12.67,11H3v2h9.67l-2.58,2.59zM19,3H5c-1.11,0 -2,0.9 -2,2v4h2V5h14v14H5v-4H3v4c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/menu/edit_contact_menu.xml
+++ b/app/src/main/res/menu/edit_contact_menu.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/share"
+        android:icon="@drawable/ic_share"
+        app:showAsAction="always"
+        android:title="@string/btn__share" />
+
+    <item
         android:id="@+id/delete"
         android:icon="@drawable/ic_delete"
         app:showAsAction="always"

--- a/app/src/main/res/menu/settings_contact_list_menu.xml
+++ b/app/src/main/res/menu/settings_contact_list_menu.xml
@@ -2,6 +2,12 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/import_contact"
+        android:icon="@drawable/ic_import"
+        app:showAsAction="always"
+        android:title="@string/btn__import_contact" />
+
+    <item
         android:id="@+id/add"
         android:icon="@drawable/ic_add"
         app:showAsAction="always"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,12 +3,14 @@
     <string name="btn__play_sound">Ton abspielen</string>
     <string name="default_contact__dad">Papa</string>
     <string name="btn__add_contact">Aufzeichnen</string>
+    <string name="btn__import_contact">Importieren</string>
     <string name="settings__category_display">Bildschirm</string>
     <string name="settings__contact">Kontakt</string>
     <string name="whats_new">Nachrichten</string>
     <string name="whats_new__title">Nachrichten</string>
     <string name="whats_new__continue">Weiter</string>
     <string name="theme_light">Licht</string>
+    <string name="btn__share">Teilen</string>
     <string name="btn__delete">Löschen</string>
     <string name="theme_dark">Dunkel</string>
     <string name="settings__category_phone">Telefon</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -31,4 +31,6 @@
     <string name="settings__category_phone">Téléphone</string>
     <string name="settings__at_least_one_contact_requried">Au moins un contact est nécessaire.</string>
     <string name="edit_contact__confirm_delete_recording_message">Supprimer cet enregistrement \?</string>
+    <string name="btn__import_contact">Importer</string>
+    <string name="btn__share">Partager</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -31,4 +31,6 @@
     <string name="whats_new">Nyheter</string>
     <string name="whats_new__title">Nyheter</string>
     <string name="contact_list__description">Legg til slektninger og venner og skru så av de forvalgte kontaktene for en mer personlig telefonopplevelse. Trykk på din tilpassede profil for å redigere den. Forvalg kan ikke redigeres, kun skrus av.</string>
+    <string name="btn__import_contact">Importere</string>
+    <string name="btn__share">Dele</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -31,4 +31,6 @@
     <string name="btn__cancel">Annuleren</string>
     <string name="settings__theme">Thema</string>
     <string name="settings__category_phone">Telefoon</string>
+    <string name="btn__import_contact">Importeren</string>
+    <string name="btn__share">Deel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,10 +15,12 @@
     <string name="default_contact__mum">Mum</string>
 
     <string name="btn__add_contact">Record</string>
+    <string name="btn__import_contact">Import Contact</string>
     <string name="btn__record_sound">Record</string>
     <string name="btn__stop_recording_sound">Stop Recording</string>
     <string name="btn__play_sound">Play sound</string>
     <string name="btn__lock">Lock</string>
+    <string name="btn__share">Share</string>
     <string name="btn__delete">Delete</string>
     <string name="btn__cancel">Cancel</string>
 


### PR DESCRIPTION
This PR adds the option to share and import Contacts.

To share a contact open it in the Details View and press the share button. A zip file is created that can be shared via messaging apps or stored on the phone.
To import contacts, go to the contact list view and press import. Chose the zip file and the contact is imported. 

This is useful as a backup, to share the same contacts as your partner or to give distant family members the app and let them record themselves.